### PR TITLE
Fixes jsonRequest respond callback. Adds echo route to endpoints in test. Adds console and exception effects.

### DIFF
--- a/src/REST/Endpoint.purs
+++ b/src/REST/Endpoint.purs
@@ -42,6 +42,7 @@ import Data.Foreign.Class (class IsForeign)
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Console (CONSOLE, log)
 
 import Data.List as L
 
@@ -81,10 +82,10 @@ class (AsForeign a) <= HasExample a where
   example :: a
 
 -- | A `Sink` receives a response.
-type Sink eff res = res -> Eff (http :: Node.HTTP | eff) Unit
+type Sink eff res = res -> Eff (http :: Node.HTTP, err :: EXCEPTION, console :: CONSOLE | eff) Unit
 
 -- | A `Source` provides a request asynchronously.
-type Source eff req = (req -> Eff (http :: Node.HTTP | eff) Unit) -> Eff (http :: Node.HTTP, err :: EXCEPTION | eff) Unit
+type Source eff req = (req -> Eff (http :: Node.HTTP, err :: EXCEPTION, console :: CONSOLE | eff) Unit) -> Eff (http :: Node.HTTP, err :: EXCEPTION, console :: CONSOLE | eff) Unit
 
 -- | A service error - status code and message.
 data ServiceError = ServiceError Int String
@@ -138,11 +139,11 @@ htmlResponse = map toClient response
   toClient res = sendResponse res 200 "text/html" <<< render
 
 -- | Serve static HTML in the response body.
-staticHtmlResponse :: forall e eff. (Endpoint e) => e (Markup _) -> e (Eff (http :: Node.HTTP | eff) Unit)
+staticHtmlResponse :: forall e eff. (Endpoint e) => e (Markup _) -> e (Eff (http :: Node.HTTP, err :: EXCEPTION, console :: CONSOLE | eff) Unit)
 staticHtmlResponse = apply htmlResponse
 
 -- | Send a basic response to the client, specifying a status code, status message and response body.
-sendResponse :: forall eff. Node.Response -> Int -> String -> String -> Eff (http :: Node.HTTP | eff) Unit
+sendResponse :: forall eff. Node.Response -> Int -> String -> String -> Eff (http :: Node.HTTP, err :: EXCEPTION, console :: CONSOLE | eff) Unit
 sendResponse res code contentType message = do
   Node.setStatusCode res code
   Node.setHeader res "Content-Type" contentType


### PR DESCRIPTION
```bash
curl -H "X-Shout: test"  -H "Content-Type: application/json" -X POST -d '{"username": "test"}' http://localhost:8080/echo
Bad request%
```

```bash
* Build successful.
* Running tests...
The API tester is configured to send requests to localhost:9000/api.
To avoid CORS issues in the browser, you should forward requests from port 9000 to 8080/8081 accordingly.
Listening on port 8080.
Serving docs on port 8081.
{"username": "test"}
```

jsonRequest returns bad request even with valid JSON body data.

https://github.com/dicomgrid/purescript-rest/pull/13